### PR TITLE
Fixed strict-transport-security (upper-camelcase needed)

### DIFF
--- a/Configuration/TypoScript/Template/00100_Config.typoscript
+++ b/Configuration/TypoScript/Template/00100_Config.typoscript
@@ -50,7 +50,7 @@ page {
             1.header = Server:
             5.header = X-Powered-By:
             ### sagt dem Browser er soll bitte gleich https verwenden !!erst ab IE 11!! Sperrt WEBMAIL
-            10.header = strict-transport-security:max-age=31536000
+            10.header = Strict-Transport-Security:max-age=31536000
             20.header = X-Frame-Options: SAMEORIGIN
             30.header = X-Xss-Protection: 1; mode=block
             40.header = X-Content-Type-Options: nosniff


### PR DESCRIPTION
I've changed the "strict-transport-security" header to upper-camelcase notation, as mentioned in the docs: 
https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security